### PR TITLE
Update to tokio 1.37 and various changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,12 @@ include = ["**/*.rs", "Cargo.toml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.37", features = ["fs"] }
+tokio = { version = "1.37", features = [
+    "fs",
+    "rt",
+    "rt-multi-thread",
+    "io-util",
+] }
 fs3 = "0.5.0"
 futures-lite = "1.11.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { version = "1.37", features = [
     "rt",
     "rt-multi-thread",
     "io-util",
+    "sync",
+    "time",
 ] }
 fs3 = "0.5.0"
 futures-lite = "1.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ include = ["**/*.rs", "Cargo.toml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.2", features = ["fs", "blocking", "rt-core"] }
+tokio = { version = "1.37", features = ["fs"] }
 fs3 = "0.5.0"
 futures-lite = "1.11.3"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.37", features = ["macros"] }
 fork = "0.1.18"
 tempfile = "3.2.0"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -3,22 +3,22 @@
 
 extern crate test;
 
-use test::Bencher;
-use tempfile::NamedTempFile;
-use tokio::fs::File;
-use tokio::prelude::io::AsyncWriteExt;
 use async_file_lock::FileLock;
+use tempfile::NamedTempFile;
+use test::Bencher;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 #[bench]
 fn tokio_write(b: &mut Bencher) {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let mut file = rt.block_on(async {
-        File::create(NamedTempFile::new().unwrap().into_temp_path()).await.unwrap()
+        File::create(NamedTempFile::new().unwrap().into_temp_path())
+            .await
+            .unwrap()
     });
     b.iter(|| {
-        rt.block_on(async {
-            file.write(b"a")
-        });
+        rt.block_on(async { file.write(b"a") });
     })
 }
 
@@ -26,14 +26,14 @@ fn tokio_write(b: &mut Bencher) {
 fn normal_write(b: &mut Bencher) {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let mut file = rt.block_on(async {
-        let mut file = FileLock::create(NamedTempFile::new().unwrap().into_temp_path()).await.unwrap();
+        let mut file = FileLock::create(NamedTempFile::new().unwrap().into_temp_path())
+            .await
+            .unwrap();
         file.lock_exclusive().await;
         file
     });
     b.iter(|| {
-        rt.block_on(async {
-            file.write(b"a")
-        });
+        rt.block_on(async { file.write(b"a") });
     })
 }
 
@@ -41,11 +41,11 @@ fn normal_write(b: &mut Bencher) {
 fn auto_write(b: &mut Bencher) {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let mut file = rt.block_on(async {
-        FileLock::create(NamedTempFile::new().unwrap().into_temp_path()).await.unwrap()
+        FileLock::create(NamedTempFile::new().unwrap().into_temp_path())
+            .await
+            .unwrap()
     });
     b.iter(|| {
-        rt.block_on(async {
-            file.write(b"a")
-        });
+        rt.block_on(async { file.write(b"a") });
     })
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,6 +456,10 @@ impl AsyncSeek for FileLock {
         if let Some(ref mut locked_file) = self.locked_file {
             return Pin::new(locked_file).as_mut().poll_complete(cx);
         }
+        // NOTE: calling this without calling start_seek might return the same result
+        if let None = self.seek_fut {
+            return Poll::Ready(Ok(0)); // but we return 0
+        }
         let (result, file) = ready!(Pin::new(self.seek_fut.as_mut().unwrap()).poll(cx)).unwrap();
         self.seek_fut = None;
         self.unlocked_file = Some(file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,11 +411,11 @@ impl AsyncWrite for FileLock {
     }
 }
 
-impl FileLock {
-    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [MaybeUninit<u8>]) -> bool {
-        false
-    }
-}
+// impl FileLock {
+//     unsafe fn prepare_uninitialized_buffer(&self, _: &mut [MaybeUninit<u8>]) -> bool {
+//         false
+//     }
+// }
 
 impl AsyncRead for FileLock {
     fn poll_read(
@@ -433,7 +433,7 @@ impl AsyncRead for FileLock {
                     return Poll::Ready(result);
                 } else {
                     self.state = State::Unlocking;
-                    self.result = Some(result.map(|x| 0u64/* x as u64 */));
+                    self.result = Some(result.map(|_| 0u64/* x as u64 */));
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::future::Future;
 use std::io::{Error, Result, Seek, SeekFrom};
-use std::mem::MaybeUninit;
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,11 +165,11 @@ impl FileLock {
     ///
     /// ```no_run
     /// use tokio::fs::File;
-    /// use tokio::prelude::*;
+    /// use tokio::io::AsyncWriteExt;
     ///
     /// # async fn dox() -> std::io::Result<()> {
     /// let mut file = File::create("foo.txt").await?;
-    /// file.write_all(b"hello, world!").await?;
+    /// file.write(b"hello, world!").await?;
     /// file.sync_all().await?;
     /// # Ok(())
     /// # }
@@ -202,11 +202,11 @@ impl FileLock {
     ///
     /// ```no_run
     /// use tokio::fs::File;
-    /// use tokio::prelude::*;
+    /// use tokio::io::AsyncWriteExt;
     ///
     /// # async fn dox() -> std::io::Result<()> {
     /// let mut file = File::create("foo.txt").await?;
-    /// file.write_all(b"hello, world!").await?;
+    /// file.write(b"hello, world!").await?;
     /// file.sync_data().await?;
     /// # Ok(())
     /// # }

--- a/tests/async_file_lock.rs
+++ b/tests/async_file_lock.rs
@@ -319,26 +319,54 @@ async fn lock_exclusive_shared() {
 }
 
 #[test(flavor = "multi_thread")]
-async fn drop_lock_exclusive() -> Result<()> {
-    let tmp_path = NamedTempFile::new()?.into_temp_path();
-    match fork() {
-        Ok(Fork::Parent(_)) => {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let mut file = FileLock::open(&tmp_path).await?;
-            let instant = Instant::now();
-            file.lock_exclusive().await?;
-            assert!(instant.elapsed().as_millis() < 100);
-        }
-        Ok(Fork::Child) => {
-            let mut file = FileLock::open(&tmp_path).await?;
-            file.lock_exclusive().await?;
-            drop(file);
-            std::thread::sleep(std::time::Duration::from_millis(1000));
-            std::process::exit(0);
-        }
-        Err(_) => panic!("unable to fork"),
-    }
-    Ok(())
+async fn drop_lock_exclusive() {
+    let file = NamedTempFile::new().unwrap();
+
+    let tmp_path: PathBuf = file.path().into();
+    let tmp_path2 = tmp_path.clone();
+
+    // signal channels
+    let (locked_tx, locked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (unlocked_tx, unlocked_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // child thread
+    tokio::spawn(async move {
+        // wait for file locked by main thread
+        assert_matches!(locked_rx.await, Ok(()));
+
+        assert!(tmp_path.exists());
+        let mut file = FileLock::open(&tmp_path).await.unwrap();
+
+        // attemp to obtain a lock acquired should failed.
+        assert_matches!(file.try_lock_exclusive(), Err(_));
+
+        // wait for lock released from main thread
+        assert_matches!(unlocked_rx.await, Ok(()));
+
+        // attemp to obtain a lock should success.
+        assert_matches!(file.try_lock_exclusive(), Ok(()));
+    });
+
+    // main thread
+    {
+        let mut file = FileLock::open(&tmp_path2).await.unwrap();
+        assert!(tmp_path2.exists());
+
+        // obtain the lock
+        assert_matches!(file.lock_exclusive().await, Ok(_));
+
+        // signal child thread
+        assert_matches!(locked_tx.send(()), Ok(()));
+
+        // sleep
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+
+        // drop lock
+        drop(file);
+
+        // signal
+        assert_matches!(unlocked_tx.send(()), Ok(()));
+    };
 }
 
 #[test(flavor = "multi_thread")]

--- a/tests/async_file_lock.rs
+++ b/tests/async_file_lock.rs
@@ -1,16 +1,11 @@
 #![deny(unused_must_use)]
 #![feature(assert_matches)]
 
-use std::io::Result;
-use std::time::Instant;
+use std::path::PathBuf;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::test;
 use {async_file_lock::FileLock, std::assert_matches::assert_matches};
-use {
-    fork::{fork, Fork},
-    std::path::PathBuf,
-};
 
 fn file() -> FileLock {
     FileLock::new_std(tempfile::tempfile().unwrap())
@@ -94,38 +89,93 @@ async fn normal1() {
     };
 }
 
-#[ignore]
 #[test(flavor = "multi_thread")]
-async fn append_mode() -> Result<()> {
-    let tmp_path = NamedTempFile::new()?.into_temp_path();
-    match fork() {
-        Ok(Fork::Parent(_)) => {
-            let mut buf = String::new();
-            let mut file = FileLock::create(&tmp_path).await?;
-            file.set_seeking_mode(SeekFrom::End(0));
-            file.write(b"a").await?;
-            // println!("parent {}", tmp_path.exists());
-            std::thread::sleep(std::time::Duration::from_millis(200));
-            file.write(b"a").await?;
-            file.seek(SeekFrom::Start(0)).await?;
-            // Turn off auto seeking mode
-            file.set_seeking_mode(SeekFrom::Current(0));
-            file.read_to_string(&mut buf).await?;
-            // Each file handle has its own position.
-            assert_eq!(buf, "bba");
-        }
-        Ok(Fork::Child) => {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            // println!("{}", tmp_path.exists());
-            let mut file = FileLock::open(&tmp_path).await?;
-            file.write(b"bb").await?;
-            file.flush().await?;
-            // println!("done");
-            std::process::exit(0);
-        }
-        Err(_) => panic!("unable to fork"),
-    }
-    Ok(())
+async fn append_mode() {
+    // let tmp_path = NamedTempFile::new()?.into_temp_path();
+    // match fork() {
+    //     Ok(Fork::Parent(_)) => {
+    //         let mut buf = String::new();
+    //         let mut file = FileLock::create(&tmp_path).await?;
+    //         file.set_seeking_mode(SeekFrom::End(0));
+    //         file.write(b"a").await?;
+    //         // println!("parent {}", tmp_path.exists());
+    //         std::thread::sleep(std::time::Duration::from_millis(200));
+    //         file.write(b"a").await?;
+    //         file.seek(SeekFrom::Start(0)).await?;
+    //         // Turn off auto seeking mode
+    //         file.set_seeking_mode(SeekFrom::Current(0));
+    //         file.read_to_string(&mut buf).await?;
+    //         // Each file handle has its own position.
+    //         assert_eq!(buf, "bba");
+    //     }
+    //     Ok(Fork::Child) => {
+    //         std::thread::sleep(std::time::Duration::from_millis(100));
+    //         // println!("{}", tmp_path.exists());
+    //         let mut file = FileLock::open(&tmp_path).await?;
+    //         file.write(b"bb").await?;
+    //         file.flush().await?;
+    //         // println!("done");
+    //         std::process::exit(0);
+    //     }
+    //     Err(_) => panic!("unable to fork"),
+    // }
+    // Ok(())
+    let file = NamedTempFile::new().unwrap();
+
+    let tmp_path: PathBuf = file.path().into();
+    let tmp_path2 = tmp_path.clone();
+
+    // signal channels
+    let (writen_tx, writen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (overwriten_tx, overwriten_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // child thread
+    tokio::spawn(async move {
+        // open file
+        let mut file = FileLock::open(&tmp_path).await.unwrap();
+        assert!(tmp_path.exists());
+
+        file.set_seeking_mode(SeekFrom::End(0));
+
+        // write to file
+        assert_matches!(file.write(b"a").await, Ok(_));
+        assert_matches!(writen_tx.send(()), Ok(()));
+
+        // wait for overwriten
+        assert_matches!(overwriten_rx.await, Ok(()));
+
+        // write, it should append to the end
+        assert_matches!(file.write(b"a").await, Ok(_));
+
+        assert_matches!(file.seek(SeekFrom::Current(0)).await, Ok(_));
+
+        // turn off auto seeking mode
+        file.set_seeking_mode(SeekFrom::Current(0));
+
+        // read content
+        let mut buf = String::new();
+        assert_matches!(file.read_to_string(&mut buf).await, Ok(_));
+
+        // assert it has been overwriten
+        assert_eq!(buf, "bba");
+    });
+
+    // main thread
+    {
+        // wait for writen signal
+        assert_matches!(writen_rx.await, Ok(()));
+
+        // open file
+        let mut file = FileLock::open(&tmp_path2).await.unwrap();
+        assert!(tmp_path2.exists());
+
+        // overwrite
+        assert_matches!(file.write(b"bb").await, Ok(_));
+        assert_matches!(file.flush().await, Ok(_));
+
+        // signal
+        assert_matches!(overwriten_tx.send(()), Ok(()));
+    };
 }
 
 #[test(flavor = "multi_thread")]

--- a/tests/async_file_lock.rs
+++ b/tests/async_file_lock.rs
@@ -17,38 +17,84 @@ fn file() -> FileLock {
 }
 
 #[test(flavor = "multi_thread")]
-async fn normal1() -> Result<()> {
-    let tmp_path = NamedTempFile::new()?.into_temp_path();
-    // let tmp_path = PathBuf::from("/tmp/a");
-    match fork() {
-        Ok(Fork::Parent(_)) => {
-            // println!("parent {}", tmp_path.exists());
-            let mut buf = String::new();
-            let mut file = FileLock::create(&tmp_path).await?;
-            // println!("parent {}", tmp_path.exists());
-            println!("written {}", file.write(b"a").await?);
-            std::thread::sleep(std::time::Duration::from_millis(200));
-            println!("slept");
-            println!("sought {}", file.seek(SeekFrom::Start(0)).await?);
-            file.read_to_string(&mut buf).await?;
-            println!("read");
-            // // We write at location 0 then it gets overridden.
-            assert_eq!(buf, "b");
-        }
-        Ok(Fork::Child) => {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            println!("child {}", tmp_path.exists());
-            let mut file = FileLock::open(&tmp_path).await?;
-            println!("child opened");
-            file.write(b"b").await?;
-            println!("done");
-            std::process::exit(0);
-        }
-        Err(_) => panic!("unable to fork"),
-    }
-    Ok(())
+async fn normal1() {
+    // let tmp_path = NamedTempFile::new()?.into_temp_path();
+    // // let tmp_path = PathBuf::from("/tmp/a");
+    // match fork() {
+    //     Ok(Fork::Parent(_)) => {
+    //         // println!("parent {}", tmp_path.exists());
+    //         let mut buf = String::new();
+    //         let mut file = FileLock::create(&tmp_path).await?;
+    //         // println!("parent {}", tmp_path.exists());
+    //         println!("writen {}", file.write(b"a").await?);
+    //         std::thread::sleep(std::time::Duration::from_millis(200));
+    //         println!("slept");
+    //         println!("sought {}", file.seek(SeekFrom::Start(0)).await?);
+    //         file.read_to_string(&mut buf).await?;
+    //         println!("read");
+    //         // // We write at location 0 then it gets overridden.
+    //         assert_eq!(buf, "b");
+    //     }
+    //     Ok(Fork::Child) => {
+    //         std::thread::sleep(std::time::Duration::from_millis(100));
+    //         println!("child {}", tmp_path.exists());
+    //         let mut file = FileLock::open(&tmp_path).await?;
+    //         println!("child opened");
+    //         file.write(b"b").await?;
+    //         println!("done");
+    //         std::process::exit(0);
+    //     }
+    //     Err(_) => panic!("unable to fork"),
+    // }
+    // Ok(())
+    let file = NamedTempFile::new().unwrap();
+
+    let tmp_path: PathBuf = file.path().into();
+    let tmp_path2 = tmp_path.clone();
+
+    // signal channels
+    let (writen_tx, writen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (overwriten_tx, overwriten_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // child thread
+    tokio::spawn(async move {
+        // open file
+        let mut file = FileLock::open(&tmp_path).await.unwrap();
+        assert!(tmp_path.exists());
+
+        // write to file
+        assert_matches!(file.write(b"a").await, Ok(_));
+        assert_matches!(writen_tx.send(()), Ok(()));
+
+        // wait for overwriten
+        assert_matches!(overwriten_rx.await, Ok(()));
+
+        // read content
+        let mut buf = String::new();
+        assert_matches!(file.read_to_string(&mut buf).await, Ok(_));
+
+        // assert it has been overwriten
+        assert_eq!(buf, "b");
+    });
+
+    // main thread
+    {
+        // open file
+        let mut file = FileLock::open(&tmp_path2).await.unwrap();
+        assert!(tmp_path2.exists());
+
+        // wait for writen signal
+        assert_matches!(writen_rx.await, Ok(()));
+
+        // overwrite
+        assert_matches!(file.write(b"b").await, Ok(_));
+
+        // signal
+        assert_matches!(overwriten_tx.send(()), Ok(()));
+    };
 }
 
+#[ignore]
 #[test(flavor = "multi_thread")]
 async fn append_mode() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
@@ -83,25 +129,72 @@ async fn append_mode() -> Result<()> {
 }
 
 #[test(flavor = "multi_thread")]
-async fn lock_shared() -> Result<()> {
-    let tmp_path = NamedTempFile::new()?.into_temp_path();
-    match fork() {
-        Ok(Fork::Parent(_)) => {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let mut file = FileLock::open(&tmp_path).await?;
-            let instant = Instant::now();
-            file.lock_shared().await?;
-            assert!(instant.elapsed().as_millis() < 100);
-        }
-        Ok(Fork::Child) => {
-            let mut file = FileLock::open(&tmp_path).await?;
-            file.lock_shared().await?;
-            std::thread::sleep(std::time::Duration::from_millis(1000));
-            std::process::exit(0);
-        }
-        Err(_) => panic!("unable to fork"),
-    }
-    Ok(())
+async fn lock_shared() {
+    // let tmp_path = NamedTempFile::new()?.into_temp_path();
+    // match fork() {
+    //     Ok(Fork::Parent(_)) => {
+    //         std::thread::sleep(std::time::Duration::from_millis(100));
+    //         let mut file = FileLock::open(&tmp_path).await?;
+    //         let instant = Instant::now();
+    //         file.lock_shared().await?;
+    //         assert!(instant.elapsed().as_millis() < 100);
+    //     }
+    //     Ok(Fork::Child) => {
+    //         let mut file = FileLock::open(&tmp_path).await?;
+    //         file.lock_shared().await?;
+    //         std::thread::sleep(std::time::Duration::from_millis(1000));
+    //         std::process::exit(0);
+    //     }
+    //     Err(_) => panic!("unable to fork"),
+    // }
+    // Ok(())
+    let file = NamedTempFile::new().unwrap();
+
+    let tmp_path: PathBuf = file.path().into();
+    let tmp_path2 = tmp_path.clone();
+
+    // signal channels
+    let (locked_tx, locked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (unlocked_tx, unlocked_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // child thread
+    tokio::spawn(async move {
+        // wait for file locked by main thread
+        assert_matches!(locked_rx.await, Ok(()));
+
+        assert!(tmp_path.exists());
+        let mut file = FileLock::open(&tmp_path).await.unwrap();
+
+        // attemp to obtain a lock acquired should failed.
+        assert_matches!(file.try_lock_shared(), Ok(_));
+
+        // wait for lock released from main thread
+        assert_matches!(unlocked_rx.await, Ok(()));
+
+        // attemp to obtain a lock should success.
+        assert_matches!(file.try_lock_shared(), Ok(()));
+    });
+
+    // main thread
+    {
+        let mut file = FileLock::open(&tmp_path2).await.unwrap();
+        assert!(tmp_path2.exists());
+
+        // obtain the lock
+        assert_matches!(file.lock_shared().await, Ok(_));
+
+        // signal child thread
+        assert_matches!(locked_tx.send(()), Ok(()));
+
+        // sleep
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+
+        // unlock
+        file.unlock().await;
+
+        // signal
+        assert_matches!(unlocked_tx.send(()), Ok(()));
+    };
 }
 
 #[test(flavor = "multi_thread")]

--- a/tests/async_file_lock.rs
+++ b/tests/async_file_lock.rs
@@ -1,18 +1,18 @@
 #![deny(unused_must_use)]
 
 use async_file_lock::FileLock;
-use tokio::test;
-use std::io::Result;
-use tempfile::NamedTempFile;
-use tokio::io::{AsyncWriteExt, SeekFrom, AsyncSeekExt, AsyncReadExt};
-use std::time::Instant;
 use fork::{fork, Fork};
+use std::io::Result;
+use std::time::Instant;
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::test;
 
 fn file() -> FileLock {
     FileLock::new_std(tempfile::tempfile().unwrap())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn normal1() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     // let tmp_path = PathBuf::from("/tmp/a");
@@ -39,13 +39,13 @@ async fn normal1() -> Result<()> {
             file.write(b"b").await?;
             println!("done");
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn append_mode() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     match fork() {
@@ -72,13 +72,13 @@ async fn append_mode() -> Result<()> {
             file.flush().await?;
             // println!("done");
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn lock_shared() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     match fork() {
@@ -94,14 +94,13 @@ async fn lock_shared() -> Result<()> {
             file.lock_shared().await?;
             std::thread::sleep(std::time::Duration::from_millis(1000));
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn lock_exclusive() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     match fork() {
@@ -119,13 +118,13 @@ async fn lock_exclusive() -> Result<()> {
             println!("child {}", tmp_path.exists());
             std::thread::sleep(std::time::Duration::from_millis(1000));
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn lock_exclusive_shared() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     match fork() {
@@ -141,13 +140,13 @@ async fn lock_exclusive_shared() -> Result<()> {
             file.lock_shared().await?;
             std::thread::sleep(std::time::Duration::from_millis(1000));
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn drop_lock_exclusive() -> Result<()> {
     let tmp_path = NamedTempFile::new()?.into_temp_path();
     match fork() {
@@ -164,13 +163,13 @@ async fn drop_lock_exclusive() -> Result<()> {
             drop(file);
             std::thread::sleep(std::time::Duration::from_millis(1000));
             std::process::exit(0);
-        },
+        }
         Err(_) => panic!("unable to fork"),
     }
     Ok(())
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn exclusive_locking_locked_file_panics() {
     let mut file = file();
@@ -178,7 +177,7 @@ async fn exclusive_locking_locked_file_panics() {
     file.lock_exclusive().await.unwrap();
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn shared_locking_locked_file_panics() {
     let mut file = file();
@@ -186,7 +185,7 @@ async fn shared_locking_locked_file_panics() {
     file.lock_shared().await.unwrap();
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn shared_locking_exclusive_file_panics() {
     let mut file = file();
@@ -194,7 +193,7 @@ async fn shared_locking_exclusive_file_panics() {
     file.lock_shared().await.unwrap();
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn exclusive_locking_shared_file_panics() {
     let mut file = file();
@@ -202,14 +201,14 @@ async fn exclusive_locking_shared_file_panics() {
     file.lock_exclusive().await.unwrap();
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn unlocking_file_panics() {
     let mut file = file();
     file.unlock().await;
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn unlocking_unlocked_file_panics() {
     let mut file = file();
@@ -218,7 +217,7 @@ async fn unlocking_unlocked_file_panics() {
     file.unlock().await;
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 async fn file_stays_locked() {
     let mut file = file();
     file.lock_exclusive().await.unwrap();
@@ -226,7 +225,7 @@ async fn file_stays_locked() {
     file.unlock().await;
 }
 
-#[test(threaded_scheduler)]
+#[test(flavor = "multi_thread")]
 #[should_panic]
 async fn file_auto_unlocks() {
     let mut file = file();


### PR DESCRIPTION
This pull request contains commits that:
 - Update tokio version to 1.37
 - Rewrite tests
 - Add github workflow
 - Fix rust toolchain to nightly
 
Tests are rewritten. Now threads are using oneshot channels to synchronize, rather than rely on sleeping time. This makes the test result stable.

Tests uses `assert_matches` that is experimental in nightly. No other code uses nightly features.